### PR TITLE
Add example that shows integration with Kinesis Video Streams.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>amazon-kinesis-video-streams-parser-library</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Video Streams Parser Library</name>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <description>The Amazon Kinesis Video Streams Parser Library for Java enables Java developers to parse the streams
         returned by GetMedia calls to Amazon Kinesis Video.
     </description>
@@ -46,6 +46,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-kinesisvideo</artifactId>
+            <version>1.11.247</version>
         </dependency>
 
         <!--- Test -->

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/GetMediaWorker.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/GetMediaWorker.java
@@ -1,0 +1,106 @@
+/*
+Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). 
+You may not use this file except in compliance with the License. 
+A copy of the License is located at
+
+   http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. 
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+*/
+package com.amazonaws.kinesisvideo.parser.examples;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.kinesisvideo.parser.ebml.InputStreamParserByteSource;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvElement;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitException;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitor;
+import com.amazonaws.kinesisvideo.parser.mkv.StreamingMkvReader;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoMedia;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoMediaClientBuilder;
+import com.amazonaws.services.kinesisvideo.model.APIName;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
+import com.amazonaws.services.kinesisvideo.model.GetMediaRequest;
+import com.amazonaws.services.kinesisvideo.model.GetMediaResult;
+import com.amazonaws.services.kinesisvideo.model.StartSelector;
+import com.amazonaws.services.kinesisvideo.model.StartSelectorType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+/**
+ * Worker used to make a GetMedia call to Kinesis Video and stream in data and parse it and apply a visitor.
+ */
+@Slf4j
+public class GetMediaWorker extends KinesisVideoCommon implements Runnable {
+    private final AmazonKinesisVideoMedia videoMedia;
+    private final MkvElementVisitor elementVisitor;
+    private final StartSelector startSelector;
+
+    private GetMediaWorker(Regions region,
+            AWSCredentialsProvider credentialsProvider,
+            String streamName,
+            StartSelector startSelector,
+            String endPoint,
+            MkvElementVisitor elementVisitor) {
+        super(region, credentialsProvider, streamName);
+
+        AmazonKinesisVideoMediaClientBuilder builder = AmazonKinesisVideoMediaClientBuilder.standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, region.getName()))
+                .withCredentials(getCredentialsProvider());
+
+        this.videoMedia = builder.build();
+        this.elementVisitor = elementVisitor;
+        this.startSelector = startSelector;
+    }
+
+    public static GetMediaWorker create(Regions region,
+            AWSCredentialsProvider credentialsProvider,
+            String streamName,
+            StartSelector startSelector,
+            AmazonKinesisVideo amazonKinesisVideo,
+            MkvElementVisitor visitor) {
+        String endPoint = amazonKinesisVideo.getDataEndpoint(new GetDataEndpointRequest().withAPIName(APIName.GET_MEDIA)
+                .withStreamName(streamName)).getDataEndpoint();
+
+        return new GetMediaWorker(region, credentialsProvider, streamName, startSelector, endPoint, visitor);
+    }
+
+    @Override
+    public void run() {
+        try {
+            log.info("Start GetMedia worker on stream {}", streamName);
+
+                GetMediaResult result = videoMedia.getMedia(new GetMediaRequest().withStreamName(streamName).withStartSelector(startSelector));
+            log.info("GetMedia called on stream {} response {} requestId {}",
+                    streamName,
+                    result.getSdkHttpMetadata().getHttpStatusCode(),
+                    result.getSdkResponseMetadata().getRequestId());
+
+            StreamingMkvReader mkvStreamReader = StreamingMkvReader.createDefault(new InputStreamParserByteSource(result.getPayload()));
+            log.info("StreamingMkvReader created for stream {} ", streamName);
+            try {
+                while (mkvStreamReader.mightHaveNext()) {
+                    Optional<MkvElement> mkvElementOptional = mkvStreamReader.nextIfAvailable();
+                    if (mkvElementOptional.isPresent()) {
+                        //Apply the MkvElement to the visitor
+                        mkvElementOptional.get().accept(elementVisitor);
+                    }
+                }
+            } catch (MkvElementVisitException e) {
+                log.error("Exception while accepting visitor {}", e);
+            }
+        } catch (Throwable t) {
+            log.error("Failure in GetMediaWorker for streamName {} {}", streamName, t.toString());
+            throw t;
+        } finally {
+            log.info("Exiting GetMediaWorker for stream {}", streamName);
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/KinesisVideoCommon.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/KinesisVideoCommon.java
@@ -1,0 +1,41 @@
+/*
+Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). 
+You may not use this file except in compliance with the License. 
+A copy of the License is located at
+
+   http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. 
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+*/
+package com.amazonaws.kinesisvideo.parser.examples;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoPutMediaClientBuilder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Abstract class for all example classes that use the Kinesis Video clients.
+ */
+@RequiredArgsConstructor
+@Getter
+public abstract class KinesisVideoCommon {
+    private final Regions region;
+    private final AWSCredentialsProvider credentialsProvider;
+    protected final String streamName;
+
+    protected void configureClient(AwsClientBuilder clientBuilder) {
+        clientBuilder.withCredentials(credentialsProvider).withRegion(region);
+    }
+
+    protected void conifgurePutMediaClient(AmazonKinesisVideoPutMediaClientBuilder builder) {
+        builder.withCredentials(credentialsProvider).withRegion(region);
+    }
+
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/KinesisVideoExample.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/KinesisVideoExample.java
@@ -1,0 +1,277 @@
+/*
+Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). 
+You may not use this file except in compliance with the License. 
+A copy of the License is located at
+
+   http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. 
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+*/
+package com.amazonaws.kinesisvideo.parser.examples;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.kinesisvideo.parser.ebml.MkvTypeInfos;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvDataElement;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitException;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitor;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvEndMasterElement;
+import com.amazonaws.kinesisvideo.parser.mkv.MkvStartMasterElement;
+import com.amazonaws.kinesisvideo.parser.mkv.visitors.CompositeMkvElementVisitor;
+import com.amazonaws.kinesisvideo.parser.utilities.FragmentMetadataVisitor;
+import com.amazonaws.kinesisvideo.parser.utilities.OutputSegmentMerger;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClientBuilder;
+import com.amazonaws.services.kinesisvideo.model.CreateStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DeleteStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.ResourceNotFoundException;
+import com.amazonaws.services.kinesisvideo.model.StartSelector;
+import com.amazonaws.services.kinesisvideo.model.StartSelectorType;
+import com.amazonaws.services.kinesisvideo.model.StreamInfo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.Validate;
+
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+/**
+ * Example for integrating with Kinesis Video.
+ * This example does:
+ * 1. Create a stream, deleting and recreating if the stream of the same name already exists.
+ * It sets the retention period of the created stream to 48 hours.
+ * 2. Call PutMedia to stream video fragments into the stream.
+ * 3. Simultaneously call GetMedia to stream video fragments out of the stream.
+ * 4. It uses the StreamingMkvParser to parse the returned the stream and perform these steps:
+ *   4.1 The GetMedia output stream has one mkv segment for each fragment. Merge the mkv segments that share track
+ *        information into a single segment.
+ *   4.2 Log when we receive the start and end of each fragment including the fragment sequence number and
+ *        millis behind now.
+ *
+ *
+ */
+@Slf4j
+public class KinesisVideoExample extends KinesisVideoCommon {
+    private static final long SLEEP_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(3);
+    private static final int DATA_RETENTION_IN_HOURS = 48;
+
+    private final AmazonKinesisVideo amazonKinesisVideo;
+    private final InputStream inputStream;
+    private final ExecutorService executorService;
+    private PutMediaWorker putMediaWorker;
+    private GetMediaProcessingArguments getMediaProcessingArguments;
+
+    @Builder
+    private KinesisVideoExample(Regions region,
+            String streamName,
+            AWSCredentialsProvider credentialsProvider,
+            InputStream inputVideoStream) {
+        super(region, credentialsProvider, streamName);
+        final AmazonKinesisVideoClientBuilder builder = AmazonKinesisVideoClientBuilder.standard();
+        configureClient(builder);
+        this.amazonKinesisVideo = builder.build();
+        this.inputStream = inputVideoStream;
+        this.executorService = Executors.newFixedThreadPool(2);
+    }
+
+    /**
+     * This method executes the example.
+     *
+     * @throws InterruptedException the thread is interrupted while waiting for the stream to enter the correct state.
+     * @throws IOException fails to read video from the input stream or write to the output stream.
+     */
+    public void execute () throws InterruptedException, IOException {
+        //Create the Kinesis Video stream, deleting and recreating if necessary.
+        recreateStreamIfNecessary();
+
+        getMediaProcessingArguments = GetMediaProcessingArguments.create();
+
+        try (GetMediaProcessingArguments getMediaProcessingArgumentsLocal = getMediaProcessingArguments) {
+            //Start a GetMedia worker to read and process data from the Kinesis Video Stream.
+            GetMediaWorker getMediaWorker = GetMediaWorker.create(getRegion(),
+                    getCredentialsProvider(),
+                    getStreamName(),
+                    new StartSelector().withStartSelectorType(StartSelectorType.EARLIEST),
+                    amazonKinesisVideo,
+                    getMediaProcessingArgumentsLocal.getMkvElementVisitor());
+            executorService.submit(getMediaWorker);
+
+            //Start a PutMedia worker to write data to a Kinesis Video Stream.
+            putMediaWorker = PutMediaWorker.create(getRegion(),
+                    getCredentialsProvider(),
+                    getStreamName(),
+                    inputStream,
+                    amazonKinesisVideo);
+            executorService.submit(putMediaWorker);
+
+            //Wait for the workers to finish.
+            executorService.shutdown();
+            executorService.awaitTermination(120, TimeUnit.SECONDS);
+            if (!executorService.isTerminated()) {
+                log.warn("Shutting down executor service by force");
+                executorService.shutdownNow();
+            } else {
+                log.info("Exeutor service is shutdown");
+            }
+        }
+
+    }
+
+    public long getFragmentsPersisted() {
+        return putMediaWorker.getNumFragmentsPersisted();
+    }
+
+    public long getFragmentsRead() {
+        return getMediaProcessingArguments.getFragmentCount();
+    }
+
+    /**
+     * If the stream exists delete it and then recreate it.
+     * Otherwise just create the stream.
+     */
+    private void recreateStreamIfNecessary() throws InterruptedException {
+        deleteStreamIfPresent();
+
+        //create the stream.
+        amazonKinesisVideo.createStream(new CreateStreamRequest().withStreamName(streamName)
+                .withDataRetentionInHours(DATA_RETENTION_IN_HOURS)
+                .withMediaType("video/h264"));
+        log.info("CreateStream called for stream {}", streamName);
+        //wait for stream to become active.
+        final Optional<StreamInfo> createdStreamInfo =
+                waitForStateToMatch((s) -> s.isPresent() && "ACTIVE".equals(s.get().getStatus()));
+        //some basic validations on the response of the create stream
+        Validate.isTrue(createdStreamInfo.isPresent());
+        Validate.isTrue(createdStreamInfo.get().getDataRetentionInHours() == DATA_RETENTION_IN_HOURS);
+        log.info("Stream {} created ARN {}", streamName, createdStreamInfo.get().getStreamARN());
+    }
+
+    private void deleteStreamIfPresent() throws InterruptedException {
+        final Optional<StreamInfo> streamInfo = getStreamInfo();
+        log.info("Stream {} exists {}", streamName, streamInfo.isPresent());
+        if (streamInfo.isPresent()) {
+            //Delete the stream
+            amazonKinesisVideo.deleteStream(new DeleteStreamRequest().withStreamARN(streamInfo.get().getStreamARN()));
+            log.info("DeleteStream called for stream {} ARN {} ", streamName, streamInfo.get().getStreamARN());
+            //Wait for stream to be deleted
+            waitForStateToMatch((s) -> !s.isPresent());
+            log.info("Stream {} deleted", streamName);
+        }
+    }
+
+    private Optional<StreamInfo> waitForStateToMatch(Predicate<Optional<StreamInfo>> statePredicate)
+            throws InterruptedException {
+        Optional<StreamInfo> streamInfo;
+        do {
+            streamInfo = getStreamInfo();
+            if (!statePredicate.test(streamInfo)) {
+                Thread.sleep(SLEEP_PERIOD_MILLIS);
+            }
+        } while (!statePredicate.test(streamInfo));
+        return streamInfo;
+    }
+
+    private Optional<StreamInfo> getStreamInfo() {
+        try {
+            return Optional.ofNullable(amazonKinesisVideo.describeStream(new DescribeStreamRequest().withStreamName(
+                    streamName)).getStreamInfo());
+        } catch (ResourceNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+
+    @RequiredArgsConstructor
+    private static class LogVisitor extends MkvElementVisitor {
+        private final FragmentMetadataVisitor fragmentMetadataVisitor;
+
+        @Getter
+        private long fragmentCount = 0;
+
+        @Override
+        public void visit(MkvStartMasterElement startMasterElement) throws MkvElementVisitException {
+            if (MkvTypeInfos.EBML.equals(startMasterElement.getElementMetaData().getTypeInfo())) {
+                fragmentCount++;
+                log.info("Start of segment  {} ", fragmentCount);
+            }
+        }
+
+        @Override
+        public void visit(MkvEndMasterElement endMasterElement) throws MkvElementVisitException {
+            if (MkvTypeInfos.SEGMENT.equals(endMasterElement.getElementMetaData().getTypeInfo())) {
+                log.info("End of segment  {} fragment # {} millisBehindNow {} ", fragmentCount,
+                        fragmentMetadataVisitor.getCurrentFragmentMetadata().get().getFragmentNumberString(),
+                        fragmentMetadataVisitor.getMillisBehindNow().getAsLong());
+            }
+        }
+
+        @Override
+        public void visit(MkvDataElement dataElement) throws MkvElementVisitException {
+        }
+    }
+
+    private static class GetMediaProcessingArguments implements Closeable {
+        private final BufferedOutputStream outputStream;
+        private final LogVisitor logVisitor;
+
+        @Getter
+        private final CompositeMkvElementVisitor mkvElementVisitor;
+
+        public GetMediaProcessingArguments(BufferedOutputStream outputStream,
+                LogVisitor logVisitor,
+                CompositeMkvElementVisitor mkvElementVisitor) {
+            this.outputStream = outputStream;
+            this.mkvElementVisitor = mkvElementVisitor;
+            this.logVisitor = logVisitor;
+        }
+
+        public static GetMediaProcessingArguments create() throws IOException {
+            //Fragment metadata visitor to extract Kinesis Video fragment metadata from the GetMedia stream.
+            FragmentMetadataVisitor fragmentMetadataVisitor = FragmentMetadataVisitor.create();
+
+            //A visitor used to log as the GetMedia stream is processed.
+            LogVisitor logVisitor = new LogVisitor(fragmentMetadataVisitor);
+
+            //An OutputSegmentMerger to combine multiple segments that share track and ebml metadata into one
+            //mkv segment.
+            OutputStream fileOutputStream = Files.newOutputStream(Paths.get("kinesis_video_example_merged_output2.mkv"),
+                    StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+            BufferedOutputStream outputStream = new BufferedOutputStream(fileOutputStream);
+            OutputSegmentMerger outputSegmentMerger = OutputSegmentMerger.createDefault(outputStream);
+
+            //A composite visitor to encapsulate the three visitors.
+            CompositeMkvElementVisitor mkvElementVisitor =
+                    new CompositeMkvElementVisitor(fragmentMetadataVisitor, outputSegmentMerger, logVisitor);
+
+            return new GetMediaProcessingArguments(outputStream, logVisitor, mkvElementVisitor);
+        }
+
+        @Override
+        public void close() throws IOException {
+            outputStream.close();
+        }
+
+        public long getFragmentCount() {
+            return logVisitor.fragmentCount;
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/PutMediaWorker.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/PutMediaWorker.java
@@ -1,0 +1,112 @@
+/*
+Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). 
+You may not use this file except in compliance with the License. 
+A copy of the License is located at
+
+   http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. 
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+*/
+package com.amazonaws.kinesisvideo.parser.examples;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoPutMedia;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoPutMediaClient;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoPutMediaClientBuilder;
+import com.amazonaws.services.kinesisvideo.PutMediaAckResponseHandler;
+import com.amazonaws.services.kinesisvideo.model.APIName;
+import com.amazonaws.services.kinesisvideo.model.AckEvent;
+import com.amazonaws.services.kinesisvideo.model.AckEventType;
+import com.amazonaws.services.kinesisvideo.model.FragmentTimecodeType;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
+import com.amazonaws.services.kinesisvideo.model.PutMediaRequest;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.InputStream;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Worker used to make a PutMedia call to Kinesis Video for a stream and stream in some video.
+ */
+@Slf4j
+public class PutMediaWorker extends KinesisVideoCommon implements Runnable {
+    private final InputStream inputStream;
+    private final AmazonKinesisVideoPutMedia putMedia;
+    @Getter
+    private long numFragmentsPersisted = 0;
+
+    private PutMediaWorker(Regions region,
+            AWSCredentialsProvider credentialsProvider,
+            String streamName,
+            InputStream inputStream,
+            String endPoint) {
+        super(region, credentialsProvider, streamName);
+        this.inputStream = inputStream;
+
+        AmazonKinesisVideoPutMediaClientBuilder builder =
+                AmazonKinesisVideoPutMediaClient.builder().withEndpoint(endPoint);
+        conifgurePutMediaClient(builder);
+        this.putMedia = builder.build();
+    }
+
+    public static PutMediaWorker create(Regions region,
+            AWSCredentialsProvider credentialsProvider,
+            String streamName,
+            InputStream inputStream,
+            AmazonKinesisVideo amazonKinesisVideo) {
+        String endPoint = amazonKinesisVideo.getDataEndpoint(new GetDataEndpointRequest().withAPIName(APIName.PUT_MEDIA)
+                .withStreamName(streamName)).getDataEndpoint();
+
+        return new PutMediaWorker(region, credentialsProvider, streamName, inputStream, endPoint);
+    }
+
+    @Override
+    public void run() {
+        CountDownLatch latch = new CountDownLatch(1);
+        putMedia.putMedia(new PutMediaRequest().withStreamName(streamName)
+                .withFragmentTimecodeType(FragmentTimecodeType.RELATIVE)
+                .withProducerStartTimestamp(new Date())
+                .withPayload(inputStream), new PutMediaAckResponseHandler() {
+            @Override
+            public void onAckEvent(AckEvent event) {
+                log.info("PutMedia Ack for stream {}: {} ", streamName, event.toString());
+                if (AckEventType.Values.PERSISTED.equals(event.getAckEventType().getEnumValue())) {
+                    numFragmentsPersisted++;
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                log.error("PutMedia for {} has suffered error {}", streamName, t);
+                latch.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                log.info("PutMedia for {} is complete ", streamName);
+                latch.countDown();
+            }
+        });
+        log.info("Made PutMedia call for stream {}", streamName);
+        try {
+            latch.await();
+            log.info("PutMedia worker exiting for stream {} number of fragments persisted {} ",
+                    streamName,
+                    numFragmentsPersisted);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Failure while waiting for PutMedia to finish", e);
+        } finally {
+            putMedia.close();
+        }
+    }
+
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/parser/TestResourceUtil.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/parser/TestResourceUtil.java
@@ -18,6 +18,8 @@ import org.apache.commons.lang3.Validate;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -58,5 +60,18 @@ public class TestResourceUtil {
         }while (readBytes >= 0);
 
         return outputStream.toByteArray();
+    }
+
+    /**
+     * Utility debug method to print the class path.
+     * Useful for verifying test setup in different build systems.
+     */
+    public static void printClassPath() {
+        ClassLoader cl = ClassLoader.getSystemClassLoader();
+        URL[] urls = ((URLClassLoader)cl).getURLs();
+
+        for(URL url: urls){
+            System.out.println(url.getFile());
+        }
     }
 }

--- a/src/test/java/com/amazonaws/kinesisvideo/parser/ebml/TestEBMLParserCallback.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/parser/ebml/TestEBMLParserCallback.java
@@ -51,7 +51,10 @@ public class TestEBMLParserCallback implements EBMLParserCallbacks {
         long elementNumber = elementMetaData.getElementNumber();
         EBMLTypeInfo typeInfo = elementMetaData.getTypeInfo();
         log.info("On Start: elementNumber " + elementNumber + " typeInfo " + typeInfo.toString() + " size "
-                + elementDataSize + " rawbytes { " + hexDump(idAndSizeRawBytes) + " }");
+                + elementDataSize);
+        if (log.isDebugEnabled()) {
+            log.debug("Rawbytes { " + hexDump(idAndSizeRawBytes) + " }");
+        }
         dumpByteBufferToRawOutput(idAndSizeRawBytes);
 
         if (checkExpectedCallbacks) {
@@ -83,7 +86,10 @@ public class TestEBMLParserCallback implements EBMLParserCallbacks {
         long elementNumber = elementMetaData.getElementNumber();
         EBMLTypeInfo typeInfo = elementMetaData.getTypeInfo();
         log.info("On PartialContent: elementCount " + elementNumber + " typeInfo " + typeInfo.toString()
-                + " bytesToRead " + bytesToRead + "rawbytes { " + hexDump(contentBuffer) + " }");
+                + " bytesToRead " + bytesToRead);
+        if (log.isDebugEnabled()) {
+            log.debug("Rawbytes { " + hexDump(contentBuffer) + " }");
+        }
 
         dumpByteBufferToRawOutput(contentBuffer);
         if (checkExpectedCallbacks) {

--- a/src/test/java/com/amazonaws/kinesisvideo/parser/examples/KinesisVideoExampleTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/parser/examples/KinesisVideoExampleTest.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). 
+You may not use this file except in compliance with the License. 
+A copy of the License is located at
+
+   http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. 
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+*/
+package com.amazonaws.kinesisvideo.parser.examples;
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.kinesisvideo.parser.TestResourceUtil;
+import com.amazonaws.regions.Regions;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Test to execute Kinesis Video Example.
+ * The test in this class are currently ignored for unit tests since they require access to Kinesis Video through
+ * valid credentials.
+ * These can be re-enabled as integration tests.
+ * They can be executed on any machine with valid aws credentials for access to Kinesis Video.
+ */
+public class KinesisVideoExampleTest {
+    @Ignore
+    @Test
+    public void testExample() throws InterruptedException, IOException {
+        KinesisVideoExample example = KinesisVideoExample.builder().region(Regions.US_WEST_2)
+                .streamName("myTestStream")
+                .credentialsProvider(new ProfileCredentialsProvider())
+                .inputVideoStream(TestResourceUtil.getTestInputStream("clusters.mkv"))
+                .build();
+
+        example.execute();
+        Assert.assertEquals(5, example.getFragmentsPersisted());
+        Assert.assertEquals(5, example.getFragmentsRead());
+    }
+
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/parser/utilities/FragmentMetadataVisitorTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/parser/utilities/FragmentMetadataVisitorTest.java
@@ -34,8 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static javafx.scene.input.KeyCode.L;
-
 /**
  * Test class to test {@link FragmentMetadataVisitor}.
  */


### PR DESCRIPTION
*Description of changes:*
Add example that shows integration with Kinesis Video Streams.
This example includes:
 1. Create a stream, deleting and recreating if the stream of the same name already exists. It sets the retention period of the created stream to 48 hours.
 2. Call PutMedia to stream video fragments into the stream.
 3. Simultaneously call GetMedia to stream video fragments out of the stream.
 4. It uses the StreamingMkvParser to parse the returned the stream and perform these steps:
   4.1 The GetMedia output stream has one mkv segment for each fragment. Merge the mkv segments that share track information into a single segment.
   4.2 Log when we receive the start and end of each fragment including the fragment sequence number and  millis behind now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
