### PR TITLE
Fix jcodec throwing an array index out of bounds exception when decoding frames where the height or width is not a multiple of 16

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameRendererVisitor.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameRendererVisitor.java
@@ -98,7 +98,10 @@ public class FrameRendererVisitor extends CompositeMkvElementVisitor {
                 decoder.addSps(avcC.getSpsList());
                 decoder.addPps(avcC.getPpsList());
 
-                Picture buf = Picture.create(pixelWidth, pixelHeight, ColorSpace.YUV420J);
+                // Width and heights must be multiples of 16, otherwise jcodec throws an array out of bounds exception
+                // https://github.com/jcodec/jcodec/issues/154
+                Picture buf = Picture.create(pixelWidth + (pixelWidth % 16), pixelHeight + (pixelHeight % 16), ColorSpace.YUV420J);
+
                 List<ByteBuffer> byteBuffers = splitMOVPacket(frameBuffer, avcC);
                 Picture pic = decoder.decodeFrameFromNals(byteBuffers, buf.getData());
 

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
@@ -63,7 +63,10 @@ public class H264FrameDecoder implements FrameVisitor.FrameProcessor  {
         decoder.addSps(avcC.getSpsList());
         decoder.addPps(avcC.getPpsList());
 
-        Picture buf = Picture.create(pixelWidth, pixelHeight, ColorSpace.YUV420J);
+        // Width and heights must be multiples of 16, otherwise jcodec throws an array out of bounds exception
+        // https://github.com/jcodec/jcodec/issues/154
+        Picture buf = Picture.create(pixelWidth + (pixelWidth % 16), pixelHeight + (pixelHeight % 16), ColorSpace.YUV420J);
+
         List<ByteBuffer> byteBuffers = splitMOVPacket(frameBuffer, avcC);
         Picture pic = decoder.decodeFrameFromNals(byteBuffers, buf.getData());
 

--- a/src/test/java/com/amazonaws/kinesisvideo/parser/utilities/FrameRendererTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/parser/utilities/FrameRendererTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 public class FrameRendererTest {
     // long running test
-    @Ignore
+
     @Test
     public void frameCountTest() throws IOException, MkvElementVisitException {
         final InputStream in = TestResourceUtil.getTestInputStream("kinesis_video_renderer_example_output.mkv");
@@ -48,8 +48,8 @@ public class FrameRendererTest {
         StreamingMkvReader mkvStreamReader =
                 StreamingMkvReader.createDefault(new InputStreamParserByteSource(in));
 
-        CountVisitor countVisitor =
-                CountVisitor.create(MkvTypeInfos.CLUSTER, MkvTypeInfos.SEGMENT, MkvTypeInfos.SIMPLEBLOCK);
+        CountVisitor countVisitor = CountVisitor.create(
+                MkvTypeInfos.CLUSTER, MkvTypeInfos.SEGMENT, MkvTypeInfos.SIMPLEBLOCK, MkvTypeInfos.TRACKS);
 
         mkvStreamReader.apply(new CompositeMkvElementVisitor(countVisitor, FrameVisitor.create(frameRenderer)));
 
@@ -61,4 +61,37 @@ public class FrameRendererTest {
         ByteBuffer codecPrivateDataFromFrame = frameRenderer.getCodecPrivateData();
         Assert.assertEquals(ByteBuffer.wrap(codecPrivateData), codecPrivateDataFromFrame);
     }
+
+    /**
+     * Test jcodec decoding a frame from an mkv that has a pixel width/height that isn't a multiple of 16
+     */
+    @Test
+    public void frameCountTest2() throws IOException, MkvElementVisitException {
+        final InputStream in = TestResourceUtil.getTestInputStream("output_get_media.mkv");
+        byte[] codecPrivateData = new byte[]{
+                0x01, 0x4d, 0x40, 0x1e, 0x03, 0x01, 0x00, 0x27, 0x27, 0x4d, 0x40, 0x1e,
+                (byte) 0xb9, 0x10, 0x14, 0x05, (byte) 0xff, 0x2e, 0x02, (byte) 0xd4, 0x04, 0x04, 0x07, (byte) 0xc0,
+                0x00, 0x00, 0x03, 0x00, 0x40, 0x00, 0x00, 0x0f, 0x38, (byte) 0xa0, 0x00, 0x3d,
+                0x09, 0x00, 0x07, (byte) 0xa1, 0x3b, (byte) 0xde, (byte) 0xe0, 0x3e, 0x11, 0x08, (byte) 0xd4, 0x01,
+                0x00, 0x04, 0x28, (byte) 0xfe, 0x3c, (byte) 0x80
+        };
+
+        H264FrameRenderer frameRenderer = H264FrameRenderer.create(new KinesisVideoFrameViewer(0, 0));
+        StreamingMkvReader mkvStreamReader =
+                StreamingMkvReader.createDefault(new InputStreamParserByteSource(in));
+
+        CountVisitor countVisitor = CountVisitor.create(
+                MkvTypeInfos.CLUSTER, MkvTypeInfos.SEGMENT, MkvTypeInfos.SIMPLEBLOCK, MkvTypeInfos.TRACKS);
+
+        mkvStreamReader.apply(new CompositeMkvElementVisitor(countVisitor, FrameVisitor.create(frameRenderer)));
+
+        Assert.assertEquals(5, countVisitor.getCount(MkvTypeInfos.TRACKS));
+        Assert.assertEquals(5, countVisitor.getCount(MkvTypeInfos.CLUSTER));
+        Assert.assertEquals(300, countVisitor.getCount(MkvTypeInfos.SIMPLEBLOCK));
+
+        Assert.assertEquals(300, frameRenderer.getFrameCount());
+        ByteBuffer codecPrivateDataFromFrame = frameRenderer.getCodecPrivateData();
+        Assert.assertEquals(ByteBuffer.wrap(codecPrivateData), codecPrivateDataFromFrame);
+    }
+
 }


### PR DESCRIPTION
Fix jcodec throwing an array index out of bounds exception when decoding frames where the height or width is not a multiple of 16

*Issue #, if available:*

Related to these issues: 
https://github.com/aws/amazon-kinesis-video-streams-parser-library/issues/7
https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/33
https://github.com/jcodec/jcodec/issues/329

*Description of changes:*
The Jcodec decoder requires that the widths and heights provided in the data buffer are multiples of 16. If this isn't the case, the decode function will throw an array index out of bounds exception. A fix to adjust the widths is provided.

A couple of extra tests are included to correctly decode frames from the "output_get_media.mkv" which were previously throwing this error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
