### PR TITLE
Release 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ with the AWS SDK for the Kinesis Video. This example provides examples for
  The Gstreamer pipeline is a toy example that demonstrates that Gstreamer can parse the mkv passed into it. 
 
 ## Release Notes
+### Release 1.0.8 (Dec 2018)
+* Add close method for derived classes to cleanup resources.
+* Add exception type which could be used in downstream frame processing logic.
+* Make boolean value thread-safe in ContinuousGetMediaWorker.
+* Remove extra exception wrapping in CompositeMkvElementVisitor.
+* Declare exception throwing for some methods.
+* Enabled stack trace in ContinuousGetMediaWorker when there is an exception.
+
 ### Release 1.0.7 (Sep 2018)
 * Add flag in KinesisVideoRendererExample and KinesisVideoExample to use the existing stream (and not doing PutMedia again if it exists already).
 * Added support to retrieve the information from FragmentMetadata and display in the image panel during rendering.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>amazon-kinesis-video-streams-parser-library</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Video Streams Parser Library</name>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.8</version>
     <description>The Amazon Kinesis Video Streams Parser Library for Java enables Java developers to parse the streams
         returned by GetMedia calls to Amazon Kinesis Video.
     </description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>amazon-kinesis-video-streams-parser-library</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Video Streams Parser Library</name>
-    <version>1.0.7</version>
+    <version>1.0.8-SNAPSHOT</version>
     <description>The Amazon Kinesis Video Streams Parser Library for Java enables Java developers to parse the streams
         returned by GetMedia calls to Amazon Kinesis Video.
     </description>

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/ContinuousGetMediaWorker.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/ContinuousGetMediaWorker.java
@@ -106,10 +106,10 @@ public class ContinuousGetMediaWorker extends KinesisVideoCommon implements Runn
                     Thread.sleep(200);
                 }
             } catch (FrameProcessException e) {
-                log.error("FrameProcessException in ContinuousGetMedia worker for stream {} {}", streamName, e);
+                log.error("FrameProcessException in ContinuousGetMedia worker for stream: " + streamName, e);
                 break;
             } catch (IOException | MkvElementVisitException e) {
-                log.error("Failure in ContinuousGetMedia worker for stream {} {}", streamName, e);
+                log.error("Failure in ContinuousGetMedia worker for stream: " + streamName, e);
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(ie);

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/mkv/FrameProcessException.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/mkv/FrameProcessException.java
@@ -1,0 +1,20 @@
+/*
+Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). 
+You may not use this file except in compliance with the License. 
+A copy of the License is located at
+
+   http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. 
+This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+*/
+package com.amazonaws.kinesisvideo.parser.mkv;
+
+public class FrameProcessException extends MkvElementVisitException {
+    public FrameProcessException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/mkv/visitors/CompositeMkvElementVisitor.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/mkv/visitors/CompositeMkvElementVisitor.java
@@ -63,17 +63,13 @@ public class CompositeMkvElementVisitor extends MkvElementVisitor {
     }
 
     private void visitAll(MkvElement element) throws MkvElementVisitException {
-        try {
-            for (MkvElementVisitor childVisitor : childVisitors) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Composite visitor calling {} on element {}",
-                            childVisitor.getClass().toString(),
-                            element.toString());
-                }
-                element.accept(childVisitor);
+        for (MkvElementVisitor childVisitor : childVisitors) {
+            if (log.isDebugEnabled()) {
+                log.debug("Composite visitor calling {} on element {}",
+                        childVisitor.getClass().toString(),
+                        element.toString());
             }
-        } catch (MkvElementVisitException e) {
-            throw new MkvElementVisitException("Composite Visitor caught exception ", e);
+            element.accept(childVisitor);
         }
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameVisitor.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameVisitor.java
@@ -52,11 +52,16 @@ public class FrameVisitor extends CompositeMkvElementVisitor {
                 tagProcessor, frameProcessor);
     }
 
-    public interface FrameProcessor {
+    public void close() {
+        frameProcessor.close();
+    }
+
+    public interface FrameProcessor extends AutoCloseable {
         default void process(Frame frame, MkvTrackMetadata trackMetadata,
                              Optional<FragmentMetadata> fragmentMetadata) {
             throw new NotImplementedException("Default FrameVisitor.FrameProcessor");
         }
+
         default void process(Frame frame, MkvTrackMetadata trackMetadata,
                              Optional<FragmentMetadata> fragmentMetadata,
                              Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
@@ -65,6 +70,12 @@ public class FrameVisitor extends CompositeMkvElementVisitor {
             } else {
                 process(frame, trackMetadata, fragmentMetadata);
             }
+        }
+
+        @Override
+        default void close() {
+            //No op close. Derived classes should implement this method to meaningfully handle cleanup of the
+            // resources.
         }
     }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameVisitor.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameVisitor.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import com.amazonaws.kinesisvideo.parser.ebml.MkvTypeInfos;
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitor;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvValue;
 import com.amazonaws.kinesisvideo.parser.mkv.visitors.CompositeMkvElementVisitor;
@@ -58,13 +59,13 @@ public class FrameVisitor extends CompositeMkvElementVisitor {
 
     public interface FrameProcessor extends AutoCloseable {
         default void process(Frame frame, MkvTrackMetadata trackMetadata,
-                             Optional<FragmentMetadata> fragmentMetadata) {
+                             Optional<FragmentMetadata> fragmentMetadata) throws FrameProcessException {
             throw new NotImplementedException("Default FrameVisitor.FrameProcessor");
         }
 
         default void process(Frame frame, MkvTrackMetadata trackMetadata,
                              Optional<FragmentMetadata> fragmentMetadata,
-                             Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
+                             Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) throws FrameProcessException {
             if (tagProcessor.isPresent()) {
                 throw new NotImplementedException("Default FrameVisitor.FrameProcessor");
             } else {

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and limitations 
 package com.amazonaws.kinesisvideo.parser.utilities;
 
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jcodec.codecs.h264.H264Decoder;
@@ -43,7 +44,7 @@ public class H264FrameDecoder implements FrameVisitor.FrameProcessor  {
     private byte[] codecPrivateData;
 
     @Override
-    public void process(Frame frame, MkvTrackMetadata trackMetadata, Optional<FragmentMetadata> fragmentMetadata) {
+    public void process(Frame frame, MkvTrackMetadata trackMetadata, Optional<FragmentMetadata> fragmentMetadata) throws FrameProcessException {
         decodeH264Frame(frame, trackMetadata);
     }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/GetMediaResponseStreamConsumer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/GetMediaResponseStreamConsumer.java
@@ -30,7 +30,7 @@ import java.io.InputStream;
  * processed or the process method decides to stop for some other reason. The FragmentMetadataCallback is invoked at
  * the end of every processed fragment.
  */
-public abstract class GetMediaResponseStreamConsumer {
+public abstract class GetMediaResponseStreamConsumer implements AutoCloseable {
 
     public abstract void process(InputStream inputStream, FragmentMetadataCallback callback)
             throws MkvElementVisitException, IOException;
@@ -40,5 +40,10 @@ public abstract class GetMediaResponseStreamConsumer {
             MkvElementVisitor mkvElementVisitor) throws MkvElementVisitException {
         StreamingMkvReader.createDefault(new InputStreamParserByteSource(inputStream))
                 .apply(FragmentProgressTracker.create(mkvElementVisitor, endOfFragmentCallback));
+    }
+
+    @Override
+    public void close() {
+        //No op close. Derived classes should implement this method to meaningfully handle cleanup of the resources.
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/GetMediaResponseStreamConsumer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/GetMediaResponseStreamConsumer.java
@@ -17,8 +17,6 @@ import com.amazonaws.kinesisvideo.parser.ebml.InputStreamParserByteSource;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitException;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitor;
 import com.amazonaws.kinesisvideo.parser.mkv.StreamingMkvReader;
-import com.amazonaws.kinesisvideo.parser.mkv.visitors.CompositeMkvElementVisitor;
-import com.amazonaws.kinesisvideo.parser.utilities.OutputSegmentMerger;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/MergedOutputPiper.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/MergedOutputPiper.java
@@ -69,5 +69,8 @@ public class MergedOutputPiper extends GetMediaResponseStreamConsumer {
         }
     }
 
-
+    @Override
+    public void close() {
+        targetProcess.destroyForcibly();
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

 * Add close method for derived classes to cleanup resources.
 * Add exception type which could be used in downstream frame processing logic.
 * Make boolean value thread-safe in ContinuousGetMediaWorker.
 * Remove extra exception wrapping in CompositeMkvElementVisitor.
 * Declare exception throwing for some methods.
 * Enabled stack trace in ContinuousGetMediaWorker when there is an exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
