### PR TITLE
release 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ with the AWS SDK for the Kinesis Video. This example provides examples for
  The Gstreamer pipeline is a toy example that demonstrates that Gstreamer can parse the mkv passed into it. 
 
 ## Release Notes
+### Release 1.0.8 (Dec 2018)
+* Add close method for derived classes to cleanup resources.
+* Add exception type which could be used in downstream frame processing logic.
+* Make boolean value thread-safe in ContinuousGetMediaWorker.
+* Remove extra exception wrapping in CompositeMkvElementVisitor.
+* Declare exception throwing for some methods.
+* Enabled stack trace in ContinuousGetMediaWorker when there is an exception.
+
 ### Release 1.0.7 (Sep 2018)
 * Add flag in KinesisVideoRendererExample and KinesisVideoExample to use the existing stream (and not doing PutMedia again if it exists already).
 * Added support to retrieve the information from FragmentMetadata and display in the image panel during rendering.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>amazon-kinesis-video-streams-parser-library</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Video Streams Parser Library</name>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.8</version>
     <description>The Amazon Kinesis Video Streams Parser Library for Java enables Java developers to parse the streams
         returned by GetMedia calls to Amazon Kinesis Video.
     </description>

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/ContinuousGetMediaWorker.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/ContinuousGetMediaWorker.java
@@ -106,10 +106,10 @@ public class ContinuousGetMediaWorker extends KinesisVideoCommon implements Runn
                     Thread.sleep(200);
                 }
             } catch (FrameProcessException e) {
-                log.error("FrameProcessException in ContinuousGetMedia worker for stream {} {}", streamName, e);
+                log.error("FrameProcessException in ContinuousGetMedia worker for stream: " + streamName, e);
                 break;
             } catch (IOException | MkvElementVisitException e) {
-                log.error("Failure in ContinuousGetMedia worker for stream {} {}", streamName, e);
+                log.error("Failure in ContinuousGetMedia worker for stream: " + streamName, e);
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(ie);

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/mkv/visitors/CompositeMkvElementVisitor.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/mkv/visitors/CompositeMkvElementVisitor.java
@@ -63,17 +63,13 @@ public class CompositeMkvElementVisitor extends MkvElementVisitor {
     }
 
     private void visitAll(MkvElement element) throws MkvElementVisitException {
-        try {
-            for (MkvElementVisitor childVisitor : childVisitors) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Composite visitor calling {} on element {}",
-                            childVisitor.getClass().toString(),
-                            element.toString());
-                }
-                element.accept(childVisitor);
+        for (MkvElementVisitor childVisitor : childVisitors) {
+            if (log.isDebugEnabled()) {
+                log.debug("Composite visitor calling {} on element {}",
+                        childVisitor.getClass().toString(),
+                        element.toString());
             }
-        } catch (MkvElementVisitException e) {
-            throw new MkvElementVisitException("Composite Visitor caught exception ", e);
+            element.accept(childVisitor);
         }
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameVisitor.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/FrameVisitor.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import com.amazonaws.kinesisvideo.parser.ebml.MkvTypeInfos;
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitor;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvValue;
 import com.amazonaws.kinesisvideo.parser.mkv.visitors.CompositeMkvElementVisitor;
@@ -58,13 +59,13 @@ public class FrameVisitor extends CompositeMkvElementVisitor {
 
     public interface FrameProcessor extends AutoCloseable {
         default void process(Frame frame, MkvTrackMetadata trackMetadata,
-                             Optional<FragmentMetadata> fragmentMetadata) {
+                             Optional<FragmentMetadata> fragmentMetadata) throws FrameProcessException {
             throw new NotImplementedException("Default FrameVisitor.FrameProcessor");
         }
 
         default void process(Frame frame, MkvTrackMetadata trackMetadata,
                              Optional<FragmentMetadata> fragmentMetadata,
-                             Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
+                             Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) throws FrameProcessException {
             if (tagProcessor.isPresent()) {
                 throw new NotImplementedException("Default FrameVisitor.FrameProcessor");
             } else {

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and limitations 
 package com.amazonaws.kinesisvideo.parser.utilities;
 
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jcodec.codecs.h264.H264Decoder;
@@ -43,7 +44,7 @@ public class H264FrameDecoder implements FrameVisitor.FrameProcessor  {
     private byte[] codecPrivateData;
 
     @Override
-    public void process(Frame frame, MkvTrackMetadata trackMetadata, Optional<FragmentMetadata> fragmentMetadata) {
+    public void process(Frame frame, MkvTrackMetadata trackMetadata, Optional<FragmentMetadata> fragmentMetadata) throws FrameProcessException {
         decodeH264Frame(frame, trackMetadata);
     }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/GetMediaResponseStreamConsumer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/consumer/GetMediaResponseStreamConsumer.java
@@ -17,8 +17,6 @@ import com.amazonaws.kinesisvideo.parser.ebml.InputStreamParserByteSource;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitException;
 import com.amazonaws.kinesisvideo.parser.mkv.MkvElementVisitor;
 import com.amazonaws.kinesisvideo.parser.mkv.StreamingMkvReader;
-import com.amazonaws.kinesisvideo.parser.mkv.visitors.CompositeMkvElementVisitor;
-import com.amazonaws.kinesisvideo.parser.utilities.OutputSegmentMerger;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add close method for derived classes to cleanup resources.
* Add exception type which could be used in downstream frame processing logic.
* Make boolean value thread-safe in ContinuousGetMediaWorker.
* Remove extra exception wrapping in CompositeMkvElementVisitor.
* Declare exception throwing for some methods.
* Enabled stack trace in ContinuousGetMediaWorker when there is an exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
