### PR TITLE
Release 1.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ To run the sample follow the below steps:
  the new Kinesis Video stream might be delayed significantly.
 
 ## Release Notes
+### Release 1.0.13 (Apr 2019)
+* Fix: Make process method in H264FrameProcessor and H264FrameDecoder throw FrameProcessException.
+
 ### Release 1.0.12 (Mar 2019)
 * Bugfix: Fix KinesisVideoExampleTest example issue that was using non-exist test file.
 * Improve KinesisVideoRekognitionLambdaExample to use AWS CloudFormation Template to create resources.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>amazon-kinesis-video-streams-parser-library</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Video Streams Parser Library</name>
-    <version>1.0.13-SNAPSHOT</version>
+    <version>1.0.13</version>
     <description>The Amazon Kinesis Video Streams Parser Library for Java enables Java developers to parse the streams
         returned by GetMedia calls to Amazon Kinesis Video.
     </description>

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/lambda/H264FrameProcessor.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/lambda/H264FrameProcessor.java
@@ -20,6 +20,7 @@ import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory;
 import com.amazonaws.kinesisvideo.parser.examples.BoundingBoxImagePanel;
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.RekognizedOutput;
 import com.amazonaws.kinesisvideo.parser.utilities.FragmentMetadata;
 import com.amazonaws.kinesisvideo.parser.utilities.FrameVisitor;
@@ -121,7 +122,7 @@ public class H264FrameProcessor implements FrameVisitor.FrameProcessor {
      */
     @Override
     public void process(final Frame frame, final MkvTrackMetadata trackMetadata,
-                        final Optional<FragmentMetadata> fragmentMetadata) {
+                        final Optional<FragmentMetadata> fragmentMetadata) throws FrameProcessException {
         if (rekognizedOutputs != null) {
 
             // Decode H264 frame

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264BoundingBoxFrameRenderer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264BoundingBoxFrameRenderer.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import com.amazonaws.kinesisvideo.parser.examples.KinesisVideoBoundingBoxFrameViewer;
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.RekognizedFragmentsIndex;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.RekognizedOutput;
 import lombok.Setter;
@@ -55,7 +56,7 @@ public class H264BoundingBoxFrameRenderer extends H264FrameRenderer {
 
     @Override
     public void process(final Frame frame, final MkvTrackMetadata trackMetadata, final Optional<FragmentMetadata> fragmentMetadata,
-                        final Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
+                        final Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) throws FrameProcessException {
         final BufferedImage bufferedImage = decodeH264Frame(frame, trackMetadata);
         final Optional<RekognizedOutput> rekognizedOutput = getRekognizedOutput(frame, fragmentMetadata);
         renderFrame(bufferedImage, rekognizedOutput);

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
@@ -48,7 +48,7 @@ public class H264FrameDecoder implements FrameVisitor.FrameProcessor  {
 
     @Override
     public void process(final Frame frame, final MkvTrackMetadata trackMetadata,
-                        final Optional<FragmentMetadata> fragmentMetadata) {
+                        final Optional<FragmentMetadata> fragmentMetadata) throws FrameProcessException {
         decodeH264Frame(frame, trackMetadata);
     }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameRenderer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameRenderer.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import com.amazonaws.kinesisvideo.parser.examples.KinesisVideoFrameViewer;
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.amazonaws.kinesisvideo.parser.utilities.BufferedImageUtil.addTextToImage;
@@ -43,7 +44,7 @@ public class H264FrameRenderer extends H264FrameDecoder {
 
     @Override
     public void process(Frame frame, MkvTrackMetadata trackMetadata, Optional<FragmentMetadata> fragmentMetadata,
-                        Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
+                        Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) throws FrameProcessException {
         final BufferedImage bufferedImage = decodeH264Frame(frame, trackMetadata);
         if (tagProcessor.isPresent()) {
             final FragmentMetadataVisitor.BasicMkvTagProcessor processor =


### PR DESCRIPTION
Adding throw FrameProcessingException to the method signature. So dependency package
can throw such exception and handler properly

*Issue #, if available:*

*Description of changes:*

* Make process method in H264FrameProcessor and H264FrameDecoder throw FrameProcessException.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
