### PR TITLE
Bug fixes in KinesisVideoRekognitionLambdaExample and some minor improvements

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/BoundingBoxImagePanel.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/BoundingBoxImagePanel.java
@@ -22,10 +22,12 @@ import com.amazonaws.kinesisvideo.parser.rekognition.pojo.BoundingBox;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.FaceType;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.MatchedFace;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.RekognizedOutput;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Panel which is used for rendering frames and embedding bounding boxes on the frames.
  */
+@Slf4j
 public class BoundingBoxImagePanel extends ImagePanel {
     private static final String DELIMITER = "-";
 
@@ -40,6 +42,7 @@ public class BoundingBoxImagePanel extends ImagePanel {
 
             // Draw bounding boxes for faces.
             if (rekognizedOutput.getFaceSearchOutputs() != null) {
+                log.debug("Number of detected faces in a frame {}", rekognizedOutput.getFaceSearchOutputs().size());
                 for (final RekognizedOutput.FaceSearchOutput faceSearchOutput : rekognizedOutput.getFaceSearchOutputs()) {
                     final FaceType detectedFaceType;
                     final String title;
@@ -60,12 +63,13 @@ public class BoundingBoxImagePanel extends ImagePanel {
                             final String[] imageIds = externalImageId.split(DELIMITER);
                             if (imageIds.length > 1) {
                                 title = imageIds[0];
-                                detectedFaceType = FaceType.valueOf(imageIds[1].toUpperCase());
+                                detectedFaceType = FaceType.fromString(imageIds[1]);
                             } else {
                                 title = "No prefix";
                                 detectedFaceType = FaceType.NOT_RECOGNIZED;
                             }
                         }
+                        log.debug("Number of matched faces for the detected face {}", faceSearchOutput.getMatchedFaceList().size());
                     } else {
                         detectedFaceType = FaceType.NOT_RECOGNIZED;
                         title = "Not recognized";

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/rekognition/pojo/FaceType.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/rekognition/pojo/FaceType.java
@@ -39,9 +39,9 @@ public enum FaceType {
 
     public static FaceType fromString(String value) {
         for (int i = 0; i < FaceType.values().length; i++) {
-            if(FaceType.values()[i].getPrefix().equals(value))
+            if(FaceType.values()[i].getPrefix().toUpperCase().equals(value.toUpperCase()))
                 return FaceType.values()[i];
         }
-        throw new UnsupportedOperationException("Not valid face type !");
+        return FaceType.UNKNOWN;
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264BoundingBoxFrameRenderer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264BoundingBoxFrameRenderer.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import com.amazonaws.kinesisvideo.parser.examples.KinesisVideoBoundingBoxFrameViewer;
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.RekognizedFragmentsIndex;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.RekognizedOutput;
 import lombok.Setter;
@@ -55,7 +56,7 @@ public class H264BoundingBoxFrameRenderer extends H264FrameRenderer {
 
     @Override
     public void process(final Frame frame, final MkvTrackMetadata trackMetadata, final Optional<FragmentMetadata> fragmentMetadata,
-                        final Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
+                        final Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) throws FrameProcessException {
         final BufferedImage bufferedImage = decodeH264Frame(frame, trackMetadata);
         final Optional<RekognizedOutput> rekognizedOutput = getRekognizedOutput(frame, fragmentMetadata);
         renderFrame(bufferedImage, rekognizedOutput);

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameDecoder.java
@@ -48,7 +48,7 @@ public class H264FrameDecoder implements FrameVisitor.FrameProcessor  {
 
     @Override
     public void process(final Frame frame, final MkvTrackMetadata trackMetadata,
-                        final Optional<FragmentMetadata> fragmentMetadata) {
+                        final Optional<FragmentMetadata> fragmentMetadata) throws FrameProcessException {
         decodeH264Frame(frame, trackMetadata);
     }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameEncoder.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameEncoder.java
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and limitations 
 package com.amazonaws.kinesisvideo.parser.utilities;
 
 import com.amazonaws.kinesisvideo.parser.examples.lambda.EncodedFrame;
+import lombok.extern.slf4j.Slf4j;
 import org.jcodec.codecs.h264.H264Encoder;
 import org.jcodec.codecs.h264.H264Utils;
 import org.jcodec.codecs.h264.encode.H264FixedRateControl;
@@ -36,6 +37,7 @@ import static java.util.Arrays.asList;
 /**
  * H264 Frame Encoder class which uses JCodec encoder to encode frames.
  */
+@Slf4j
 public class H264FrameEncoder {
 
     private Picture toEncode;
@@ -86,6 +88,8 @@ public class H264FrameEncoder {
 
         // First frame is treated as I Frame (IDR Frame)
         final SliceType sliceType = this.frameNumber == 0 ? SliceType.I : SliceType.P;
+        log.debug("Encoding frame no: {}, frame type : {}", frameNumber, sliceType);
+
         final boolean idr = this.frameNumber == 0;
 
         // Encode image into H.264 frame, the result is stored in 'out' buffer

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameRenderer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264FrameRenderer.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import com.amazonaws.kinesisvideo.parser.examples.KinesisVideoFrameViewer;
 import com.amazonaws.kinesisvideo.parser.mkv.Frame;
+import com.amazonaws.kinesisvideo.parser.mkv.FrameProcessException;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.amazonaws.kinesisvideo.parser.utilities.BufferedImageUtil.addTextToImage;
@@ -43,7 +44,7 @@ public class H264FrameRenderer extends H264FrameDecoder {
 
     @Override
     public void process(Frame frame, MkvTrackMetadata trackMetadata, Optional<FragmentMetadata> fragmentMetadata,
-                        Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
+                        Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) throws FrameProcessException {
         final BufferedImage bufferedImage = decodeH264Frame(frame, trackMetadata);
         if (tagProcessor.isPresent()) {
             final FragmentMetadataVisitor.BasicMkvTagProcessor processor =

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/ProducerStreamUtil.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/ProducerStreamUtil.java
@@ -124,7 +124,7 @@ public final class ProducerStreamUtil {
                 MAX_LATENCY_ZERO,
                 DEFAULT_GOP_DURATION * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
                 KEYFRAME_FRAGMENTATION,
-                SDK_GENERATES_TIMECODES,
+                USE_FRAME_TIMECODES,
                 configuration.getIsAbsoluteTimecode(),
                 REQUEST_FRAGMENT_ACKS,
                 RECOVER_ON_FAILURE,

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -3,12 +3,6 @@ log4j.rootLogger = INFO, LAMBDA, CONSOLE
 
 #Define the LAMBDA appender
 log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.immediateFlush=true
 log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%m%ns
-
-#Define console appender 
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.target=System.out
-log4j.appender.CONSOLE.immediateFlush=true
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%m%n
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%m%n

--- a/src/test/java/com/amazonaws/kinesisvideo/parser/rekognition/processor/RekognitionStreamProcessorTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/parser/rekognition/processor/RekognitionStreamProcessorTest.java
@@ -13,11 +13,13 @@ See the License for the specific language governing permissions and limitations 
 */
 package com.amazonaws.kinesisvideo.parser.rekognition.processor;
 
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.kinesisvideo.parser.rekognition.pojo.RekognitionInput;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.rekognition.model.CreateStreamProcessorResult;
 import com.amazonaws.services.rekognition.model.DescribeStreamProcessorResult;
+import com.amazonaws.services.rekognition.model.ListStreamProcessorsResult;
 import com.amazonaws.services.rekognition.model.StartStreamProcessorResult;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
@@ -62,6 +64,12 @@ public class RekognitionStreamProcessorTest {
     public void describeStreamProcessor() {
         final DescribeStreamProcessorResult result = streamProcessor.describeStreamProcessor();
         log.info("Status for stream processor : {}", result.getStatus());
+    }
+
+    @Test
+    public void listStreamProcessor() {
+        final ListStreamProcessorsResult result = streamProcessor.listStreamProcessor();
+        log.info("List StreamProcessors : {}", result);
     }
 
 }


### PR DESCRIPTION
**List of changes:**
1. Fixed frame timecode during re-encoding in KinesisVideoRekognitionLambdaExample
2. Fixed region for derived KVS Stream
3. Using default FaceType for external image ids that doesn't follow specified format
4. Upgraded JCodec version to 0.2.3 which provides scaling list support
5. Log improvements

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
