### PR TITLE
Add ListFragment worker and update GetMediaForFragmentListWorker

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/GetMediaForFragmentListWorker.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/GetMediaForFragmentListWorker.java
@@ -29,18 +29,19 @@ import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
 import com.amazonaws.services.kinesisvideo.model.GetMediaForFragmentListRequest;
 import com.amazonaws.services.kinesisvideo.model.GetMediaForFragmentListResult;
 import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
 @Slf4j
 public class GetMediaForFragmentListWorker extends KinesisVideoCommon implements Runnable {
     private final AmazonKinesisVideoArchivedMedia amazonKinesisVideoArchivedMedia;
     private final MkvElementVisitor elementVisitor;
-    private final String fragmentNumber;
+    private final List<String> fragmentNumbers;
 
-    public GetMediaForFragmentListWorker(final String streamName, final String fragmentNumber,
+    public GetMediaForFragmentListWorker(final String streamName, final List<String> fragmentNumbers,
                                          final AWSCredentialsProvider awsCredentialsProvider, final String endPoint,
                                          final Regions region, final MkvElementVisitor elementVisitor) {
         super(region, awsCredentialsProvider, streamName);
-        this.fragmentNumber = fragmentNumber;
+        this.fragmentNumbers = fragmentNumbers;
         this.elementVisitor = elementVisitor;
         amazonKinesisVideoArchivedMedia = AmazonKinesisVideoArchivedMediaClient
                 .builder()
@@ -50,7 +51,7 @@ public class GetMediaForFragmentListWorker extends KinesisVideoCommon implements
     }
 
 
-    public static GetMediaForFragmentListWorker create(final String streamName, final String fragmentNumber,
+    public static GetMediaForFragmentListWorker create(final String streamName, final List<String> fragmentNumbers,
                                                        final AWSCredentialsProvider awsCredentialsProvider,
                                                        final Regions region,
                                                        final AmazonKinesisVideo amazonKinesisVideo,
@@ -59,7 +60,7 @@ public class GetMediaForFragmentListWorker extends KinesisVideoCommon implements
                 .withAPIName(APIName.GET_MEDIA_FOR_FRAGMENT_LIST).withStreamName(streamName);
         final String endpoint = amazonKinesisVideo.getDataEndpoint(request).getDataEndpoint();
         return new GetMediaForFragmentListWorker(
-                streamName, fragmentNumber, awsCredentialsProvider, endpoint, region, elementVisitor);
+                streamName, fragmentNumbers, awsCredentialsProvider, endpoint, region, elementVisitor);
     }
 
     @Override
@@ -68,7 +69,7 @@ public class GetMediaForFragmentListWorker extends KinesisVideoCommon implements
             log.info("Start GetMediaForFragmentList worker on stream {}", streamName);
             final GetMediaForFragmentListResult result = amazonKinesisVideoArchivedMedia.getMediaForFragmentList(
                     new GetMediaForFragmentListRequest()
-                            .withFragments(fragmentNumber)
+                            .withFragments(fragmentNumbers)
                             .withStreamName(streamName));
 
             log.info("GetMediaForFragmentList called on stream {} response {} requestId {}",

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/examples/ListFragmentWorker.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/examples/ListFragmentWorker.java
@@ -1,0 +1,98 @@
+package com.amazonaws.kinesisvideo.parser.examples;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoArchivedMedia;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoArchivedMediaClient;
+import com.amazonaws.services.kinesisvideo.model.*;
+import lombok.extern.slf4j.Slf4j;
+
+/* This worker retrieves all fragments within the specified TimestampRange from a specified Kinesis Video Stream and returns them in a list */
+
+@Slf4j
+public class ListFragmentWorker extends KinesisVideoCommon implements Callable {
+    private final FragmentSelector fragmentSelector;
+    private final AmazonKinesisVideoArchivedMedia amazonKinesisVideoArchivedMedia;
+    private final long fragmentsPerRequest = 100;
+
+    public ListFragmentWorker(final String streamName,
+                              final AWSCredentialsProvider awsCredentialsProvider, final String endPoint,
+                              final Regions region,
+                              final FragmentSelector fragmentSelector) {
+        super(region, awsCredentialsProvider, streamName);
+        this.fragmentSelector = fragmentSelector;
+
+        amazonKinesisVideoArchivedMedia = AmazonKinesisVideoArchivedMediaClient
+                .builder()
+                .withCredentials(awsCredentialsProvider)
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, region.getName()))
+                .build();
+    }
+
+    public static ListFragmentWorker create(final String streamName,
+                                            final AWSCredentialsProvider awsCredentialsProvider,
+                                            final Regions region,
+                                            final AmazonKinesisVideo amazonKinesisVideo,
+                                            final FragmentSelector fragmentSelector) {
+        final GetDataEndpointRequest request = new GetDataEndpointRequest()
+                .withAPIName(APIName.LIST_FRAGMENTS).withStreamName(streamName);
+        final String endpoint = amazonKinesisVideo.getDataEndpoint(request).getDataEndpoint();
+
+        return new ListFragmentWorker(
+                streamName, awsCredentialsProvider, endpoint, region, fragmentSelector);
+    }
+
+    @Override
+    public List<String> call() {
+        List<String> fragmentNumbers = new ArrayList<>();
+        try {
+            log.info("Start ListFragment worker on stream {}", streamName);
+
+            ListFragmentsRequest request = new ListFragmentsRequest()
+                    .withStreamName(streamName).withFragmentSelector(fragmentSelector).withMaxResults(fragmentsPerRequest);
+
+            ListFragmentsResult result = amazonKinesisVideoArchivedMedia.listFragments(request);
+
+
+            log.info("List Fragments called on stream {} response {} request ID {}",
+                    streamName,
+                    result.getSdkHttpMetadata().getHttpStatusCode(),
+                    result.getSdkResponseMetadata().getRequestId());
+
+            for (Fragment f: result.getFragments()) {
+                fragmentNumbers.add(f.getFragmentNumber());
+            }
+            String nextToken = result.getNextToken();
+
+            /* If result is truncated, keep making requests until nextToken is empty */
+            while (nextToken != null) {
+                request = new ListFragmentsRequest()
+                        .withStreamName(streamName).withNextToken(nextToken);
+                result = amazonKinesisVideoArchivedMedia.listFragments(request);
+
+                for (Fragment f: result.getFragments()) {
+                    fragmentNumbers.add(f.getFragmentNumber());
+                }
+                nextToken = result.getNextToken();
+            }
+            Collections.sort(fragmentNumbers);
+
+            for (String f: fragmentNumbers) {
+                log.info("Retrieved fragment number {} ", f);
+            }
+        }
+        catch (Throwable t) {
+            log.error("Failure in ListFragmentWorker for streamName {} {}", streamName, t.toString());
+            throw t;
+        } finally {
+            log.info("Retrieved {} Fragments and exiting ListFragmentWorker for stream {}", fragmentNumbers.size(), streamName);
+            return fragmentNumbers;
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the parser library does not contain any examples utilizing the ListFragments API for archived media retrieval. I added a worker written in the same vein as the other workers. Given a timestamp range object, the worker will return a list of fragment numbers retrieved within a given Kinesis Video Stream during that period. 

Furthermore, the current GetMediaForFragmentListWorker only performs GetMedia for a single fragment number. I made a simple update so that it will retrieve media for a list of fragment numbers instead. Together, these two workers can retrieve and process archived media from a given timestamp range with ease.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
