### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,13 +149,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update log4j to 2.17.1 to address CVE-2021-44832.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
